### PR TITLE
Complete Google sign-in flow: resolve, link, and refresh token

### DIFF
--- a/src/app/[countryCode]/(main)/auth/google/callback/action.ts
+++ b/src/app/[countryCode]/(main)/auth/google/callback/action.ts
@@ -6,43 +6,66 @@ import { revalidateTag } from "next/cache"
 
 export async function handleGoogleCallback(queryParams: Record<string, string>) {
   try {
-    // Validate callback with Medusa
-    const token = await sdk.auth.callback("customer", "google", queryParams)
+    const backendUrl = process.env.MEDUSA_BACKEND_URL
+    const publishableKey = process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY || ""
 
-    // Store token using the centralized function
-    await setAuthToken(token as string)
+    // Validate callback with Medusa — returns a registration token (empty
+    // actor_id) on first Google sign-in, or a full token if already linked.
+    let token = (await sdk.auth.callback("customer", "google", queryParams)) as string
 
-    // Decode token to check if customer exists
-    const tokenPayload = JSON.parse(
-      Buffer.from((token as string).split(".")[1], "base64").toString()
-    )
+    const tokenPayload = JSON.parse(Buffer.from(token.split(".")[1], "base64").toString())
+    const needsSetup = !tokenPayload.actor_id || tokenPayload.actor_id === ""
 
-    const shouldCreateCustomer = !tokenPayload.actor_id || tokenPayload.actor_id === ""
-
-    if (shouldCreateCustomer) {
+    if (needsSetup) {
       const headers = {
         authorization: `Bearer ${token}`,
+        "x-publishable-api-key": publishableKey,
       }
 
-      // The callback JWT only carries actor_id/auth_identity_id — Google's
-      // profile lives on the provider identity record, fetched separately.
-      const identityRes = await fetch(
-        `${process.env.MEDUSA_BACKEND_URL}/store/custom/auth/google-identity`,
-        {
-          headers: {
-            ...headers,
-            "x-publishable-api-key": process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY || "",
-          },
-        }
-      )
-      const { email } = (await identityRes.json()) as { email: string | null }
+      // Resolve the Google email + link this identity to an existing customer
+      // if one already has that email. Google's profile isn't in the JWT, so
+      // this must happen server-side against the auth identity record.
+      const resolveRes = await fetch(`${backendUrl}/store/custom/auth/google-resolve`, {
+        method: "POST",
+        headers,
+      })
+
+      if (!resolveRes.ok) {
+        throw new Error(`Failed to resolve Google account (${resolveRes.status})`)
+      }
+
+      const { email, existed } = (await resolveRes.json()) as {
+        email: string | null
+        existed: boolean
+      }
 
       if (!email) {
         throw new Error("Could not retrieve email from Google account")
       }
 
-      await sdk.store.customer.create({ email }, {}, headers)
+      // No existing customer for this email — create one (also links the
+      // auth identity to the new customer).
+      if (!existed) {
+        await sdk.store.customer.create({ email }, {}, { authorization: `Bearer ${token}` })
+      }
+
+      // The current token predates the link — refresh it so the new token
+      // carries actor_id and actually authenticates the customer.
+      const refreshRes = await fetch(`${backendUrl}/auth/token/refresh`, {
+        method: "POST",
+        headers,
+      })
+
+      if (!refreshRes.ok) {
+        throw new Error(`Failed to refresh auth token (${refreshRes.status})`)
+      }
+
+      const refreshed = (await refreshRes.json()) as { token: string }
+      token = refreshed.token
     }
+
+    // Store the final, actor-bearing token.
+    await setAuthToken(token)
 
     // Revalidate customer cache
     const customerCacheTag = await getCacheTag("customers")


### PR DESCRIPTION
Replaces the incomplete callback handling that read email from the JWT (never present) and never refreshed the token (so actor_id stayed empty and the customer was never actually logged in). Now: resolve email + link any existing customer via the backend google-resolve route, create a customer only when none exists, then refresh the token so it carries actor_id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google sign-in handling for new and returning customers.
  * Prevented duplicate customer records by checking whether an account already exists before creating one.
  * Ensured newly created or linked accounts receive a refreshed authentication session.
  * Improved reliability of the sign-in flow when initial account setup is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->