### PR TITLE
fix: wire up Forgot Password button on account sign-in

### DIFF
--- a/src/app/components/AccountPage.tsx
+++ b/src/app/components/AccountPage.tsx
@@ -207,6 +207,7 @@ export function AccountPage() {
               <div className="text-right">
                 <button
                   type="button"
+                  onClick={() => router.push(`/${countryCode}/forgot-password`)}
                   className="font-din-arabic text-sm text-black/70 hover:text-black transition-colors"
                 >
                   Forgot your Password?


### PR DESCRIPTION
Button had no onClick/href, so it did nothing. Routes to /[countryCode]/forgot-password now, same as other sign-in flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Forgot your Password?” button now correctly navigates to the password recovery page when selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->